### PR TITLE
Remove design addon

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,5 +1,4 @@
-import '@storybook/addon-contexts/register';
-import 'storybook-addon-designs/register';
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-jest/register';
+import '@storybook/addon-contexts/register';
 import '@storybook/addon-viewport/register';

--- a/package-lock.json
+++ b/package-lock.json
@@ -16971,12 +16971,6 @@
       "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "dev": true
     },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
-      "dev": true
-    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -17223,12 +17217,6 @@
         "pify": "^4.0.1",
         "semver": "^5.6.0"
       }
-    },
-    "make-event-props": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-1.2.0.tgz",
-      "integrity": "sha512-BmWFkm/jZzVH9A0tEBdkjAARUz/eha+5IRyfOndeSMKRadkgR5DawoBHoRwLxkYmjJOI5bHkXKpaZocxj+dKgg==",
-      "dev": true
     },
     "makeerror": {
       "version": "1.0.11",
@@ -17642,12 +17630,6 @@
           }
         }
       }
-    },
-    "merge-class-names": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge-class-names/-/merge-class-names-1.2.0.tgz",
-      "integrity": "sha512-ifHxhC8DojHT1rG3PHCaJYInUqPd0WO+PxsaYDMkgy7RzfyOFtnlpr/hbhki+m/3R/ujIRVnZkD/AHjgjb5uhg==",
-      "dev": true
     },
     "merge-deep": {
       "version": "3.0.2",
@@ -18127,12 +18109,6 @@
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
-    },
-    "node-ensure": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
-      "integrity": "sha1-7K52QVDemYYexcgQ/V0Jaxg5Mqc=",
-      "dev": true
     },
     "node-eta": {
       "version": "0.9.0",
@@ -19332,16 +19308,6 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "pdfjs-dist": {
-      "version": "2.1.266",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.1.266.tgz",
-      "integrity": "sha512-Jy7o1wE3NezPxozexSbq4ltuLT0Z21ew/qrEiAEeUZzHxMHGk4DUV1D7RuCXg5vJDvHmjX1YssN+we9QfRRgXQ==",
-      "dev": true,
-      "requires": {
-        "node-ensure": "^0.0.0",
-        "worker-loader": "^2.0.0"
       }
     },
     "pend": {
@@ -21035,20 +21001,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
       "dev": true
-    },
-    "react-pdf": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-4.1.0.tgz",
-      "integrity": "sha512-SYwkWc+vRQHfrpDls3DOgn4G+wT0mYGJRor20e28GPRW8VB+6o8WqZ4QZxsl50z+dKM7UscXFnK/02eN3NXi2g==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "lodash.once": "^4.1.1",
-        "make-event-props": "^1.1.0",
-        "merge-class-names": "^1.1.1",
-        "pdfjs-dist": "2.1.266",
-        "prop-types": "^15.6.2"
-      }
     },
     "react-popper": {
       "version": "1.3.4",
@@ -23758,15 +23710,6 @@
       "integrity": "sha512-JmK+95jLX2zAP75DVAJ1HAziQ6f+f495h4P9ez2qbmxazN6fE7doWlitqx9hj2YohH3kOi6RVksJe1UH0sJfPw==",
       "dev": true
     },
-    "storybook-addon-designs": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/storybook-addon-designs/-/storybook-addon-designs-5.1.1.tgz",
-      "integrity": "sha512-fPDr6szeyMJTPlZtHRdfgwrCCDpVMqheBfXKbG8XftXW6GS1isYIT8txS1I3BOJW0cU69NxkB3+2ckEYvRMHrQ==",
-      "dev": true,
-      "requires": {
-        "react-pdf": "^4.0.5"
-      }
-    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -26166,28 +26109,6 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
-      }
-    },
-    "worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "0.4.7",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
-          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
-          "dev": true,
-          "requires": {
-            "ajv": "^6.1.0",
-            "ajv-keywords": "^3.1.0"
-          }
-        }
       }
     },
     "worker-rpc": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "react-redux": "^7.1.0",
     "redux": "^4.0.4",
     "sass-loader": "^8.0.0",
-    "storybook-addon-designs": "^5.1.1",
     "style-loader": "^1.0.0"
   },
   "keywords": [

--- a/src/atoms/button/button.stories.js
+++ b/src/atoms/button/button.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Button, CopyButton, AnchorButton } from 'atoms/button';
 import { text, boolean } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import regularButtonMdx from './regularButton/docs.mdx';
 import copyButtonMdx from './copyButton/docs.mdx';
 import anchorButtonMdx from './anchorButton/docs.mdx';
@@ -19,17 +18,9 @@ export const button = () => {
 };
 button.story = {
   component: Button,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: regularButtonMdx,
-    },
-    design: {
-      name: 'button',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=271%3A0',
     },
     jest: [
       'button',
@@ -45,17 +36,9 @@ export const copyButton = () => {
 };
 copyButton.story = {
   component: CopyButton,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: copyButtonMdx,
-    },
-    design: {
-      name: 'copyButton',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=253%3A0',
     },
     jest: [
       'copyButton',

--- a/src/atoms/card/card.stories.js
+++ b/src/atoms/card/card.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import Card from 'atoms/card';
 import { text } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|Card',
   component: Card,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'card',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=312%3A0',
     },
     jest: [
       'card',

--- a/src/atoms/expertise/expertise.stories.js
+++ b/src/atoms/expertise/expertise.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import Expertise, { EXPERTISE_LEVELS } from 'atoms/expertise';
 import { radios } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|Expertise',
   component: Expertise,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'expertise',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=80%3A10',
     },
     jest: [
       'expertise',

--- a/src/atoms/navButton/navButton.stories.js
+++ b/src/atoms/navButton/navButton.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import NavButton, { NAV_ICONS } from 'atoms/navButton';
 import { text, radios, boolean } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|NavButton',
   component: NavButton,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'navButton',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=302%3A51',
     },
     jest: [
       'navButton',

--- a/src/atoms/search/search.stories.js
+++ b/src/atoms/search/search.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import Search from 'atoms/search';
 import { text } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|Search',
   component: Search,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'search',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=235%3A59',
     },
     jest: [
       'search',

--- a/src/atoms/tag/tag.stories.js
+++ b/src/atoms/tag/tag.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import Tag from 'atoms/tag';
 import { text } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|Tag',
   component: Tag,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'tag',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=193%3A0',
     },
     jest: [
       'tag',

--- a/src/atoms/toast/toast.stories.js
+++ b/src/atoms/toast/toast.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import Toast from 'atoms/toast';
 import { text } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Atoms|Toast',
   component: Toast,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'toast',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=237%3A36',
     },
     jest: [
       'toast',

--- a/src/molecules/navBar/navBar.stories.js
+++ b/src/molecules/navBar/navBar.stories.js
@@ -1,23 +1,13 @@
 import React from 'react';
 import NavBar from 'molecules/navBar';
-import { text, radios, boolean } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Molecules|NavBar',
   component: NavBar,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'navBar',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=302%3A51',
     },
     jest: [
       'navBar',

--- a/src/molecules/tagList/tagList.stories.js
+++ b/src/molecules/tagList/tagList.stories.js
@@ -1,23 +1,14 @@
 import React from 'react';
 import TagList from 'molecules/tagList';
 import { array } from '@storybook/addon-knobs';
-import { withDesign } from 'storybook-addon-designs';
 import mdx from './docs.mdx';
 
 export default {
   title: 'Molecules|TagList',
   component: TagList,
-  decorators: [
-    withDesign,
-  ],
   parameters: {
     docs: {
       page: mdx,
-    },
-    design: {
-      name: 'tag',
-      type: 'figma',
-      url: 'https://www.figma.com/file/oY0oRyqDxQZMeMqG4BSwrf/30-seconds-web?node-id=193%3A0',
     },
     jest: [
       'tagList',


### PR DESCRIPTION
Remove design addon from Storybook.

This is temporary, as our Figma files are incomplete and we lack the time to work on these very thoroughly. I will update the styleguides as we go and, hopefully, enable the plugin later down the line once again.