### PR TITLE
Add keyphrase query handling for home page

### DIFF
--- a/src/lang/literals_en.js
+++ b/src/lang/literals_en.js
@@ -72,7 +72,6 @@ const literals = {
   'Search': 'Search',
   'Search results for': keyphrase => `Search results for ${keyphrase}`,
   'Search results': 'Search results',
-  'We couldn\'t find any results for the keyphrase ': keyphrase => `We couldn't find any results for the keyphrase ${keyphrase}`,
   'Click to view more results': 'Click to view more results',
   'Copy to clipboard': 'Copy to clipboard',
   'Examples': 'Examples',
@@ -136,6 +135,7 @@ const literals = {
   'Recommended snippets': 'Recommended snippets',
   'Like 30 seconds of code?': 'Like 30 seconds of code?',
   'Star it on GitHub': 'Star it on GitHub',
+  'We couldn\'t find any results for the keyphrase ': 'We couldn\'t find any results for the keyphrase ',
 };
 
 export default literals;

--- a/src/templates/homePage/index.jsx
+++ b/src/templates/homePage/index.jsx
@@ -58,7 +58,7 @@ const HomePage = ({
         <p className='home-sub-title'>
           { _l('site.description') }
         </p>
-        <Search shouldUpdateHistory={ false } />
+        <Search shouldUpdateHistory />
         <SearchResults isCompact />
         <ListingAnchors items={ listingAnchors } />
         <RecommendationList snippetList={ recommendedSnippets } />


### PR DESCRIPTION
- Handle `?keyphrase=...` in home page search.
- Fix a broken string literal in search results.