### PR TITLE
Performance improvements

### DIFF
--- a/content/resolvers/jsxResolver.js
+++ b/content/resolvers/jsxResolver.js
@@ -6,7 +6,7 @@ import {
 const getTextualContent = (str, noExplain = false) => {
   const result = str.slice(0, str.indexOf('<div class="gatsby-highlight"'));
   if (noExplain)
-    return result.slice(0, result.indexOf('</p>\n'));
+    return result.slice(0, result.indexOf('</p>\n') + 4);
 
   return result;
 };

--- a/content/resolvers/stdResolver.js
+++ b/content/resolvers/stdResolver.js
@@ -6,7 +6,7 @@ import {
 const getTextualContent = (str, noExplain = false) => {
   const result = str.slice(0, str.indexOf('<div class="gatsby-highlight"'));
   if (noExplain)
-    return result.slice(0, result.indexOf('</p>\n'));
+    return result.slice(0, result.indexOf('</p>\n') + 4);
   return result;
 };
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,7 +37,6 @@ module.exports = {
       },
     },
     `gatsby-plugin-sass`,
-    `gatsby-transformer-json`,
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,6 +5,7 @@ const {
   sourceNodes,
   createResolvers,
   createPages,
+  onCreateWebpackConfig,
 } = require(`./src/functions/build`);
 const {
   createPagesQuery,
@@ -42,3 +43,5 @@ exports.onCreateNode = onCreateNode;
 exports.sourceNodes = sourceNodes(requirables, reducers);
 
 exports.createResolvers = createResolvers(resolvers);
+
+exports.onCreateWebpackConfig = onCreateWebpackConfig;

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "gatsby-remark-images": "^3.1.6",
     "gatsby-remark-prismjs": "^3.3.3",
     "gatsby-source-filesystem": "^2.1.5",
-    "gatsby-transformer-json": "^2.2.2",
     "gatsby-transformer-remark": "^2.6.6",
     "gatsby-transformer-sharp": "^2.2.3",
     "glob": "^7.1.5",

--- a/src/functions/build/index.js
+++ b/src/functions/build/index.js
@@ -2,10 +2,12 @@ import onCreateNode from './onCreateNode';
 import sourceNodes from './sourceNodes';
 import createResolvers from './createResolvers';
 import createPages from './createPages';
+import onCreateWebpackConfig from './onCreateWebpackConfig';
 
 export {
   onCreateNode,
   sourceNodes,
   createResolvers,
   createPages,
+  onCreateWebpackConfig,
 };

--- a/src/functions/build/onCreateWebpackConfig.js
+++ b/src/functions/build/onCreateWebpackConfig.js
@@ -1,0 +1,15 @@
+/**
+ * When called, allows modifying the default webpack config using webpack-merge.
+ * Removes sourcemaps from production builds.
+ */
+const onCreateWebpackConfig = ({ actions, stage }) => {
+  // If production JavaScript and CSS build
+  if (stage === 'build-javascript') {
+    // Turn off source maps
+    actions.setWebpackConfig({
+      devtool: false,
+    });
+  }
+};
+
+export default onCreateWebpackConfig;

--- a/src/functions/utils/array.js
+++ b/src/functions/utils/array.js
@@ -29,8 +29,8 @@ export const transformSnippetIndex = edges =>
       title: node.title,
       expertise: node.expertise,
       primaryTag: node.tags.primary,
-      language: node.language,
-      html: node.html,
+      language: node.language.long,
+      description: node.html.description.trim(),
       url: node.slug,
       searchTokens: node.searchTokens,
     }));

--- a/src/molecules/previewCard/index.jsx
+++ b/src/molecules/previewCard/index.jsx
@@ -20,10 +20,10 @@ const PreviewCard = ({
   >
     <Card className={ trimWhiteSpace`preview-card ${className}` } { ...rest } >
       <h4 className='card-title'>{ snippet.title }</h4>
-      <TagList tags={ [snippet.language.long, snippet.primaryTag, snippet.expertise] } />
+      <TagList tags={ [snippet.language, snippet.primaryTag, snippet.expertise] } />
       <div
         className='card-description'
-        dangerouslySetInnerHTML={ { __html: `${snippet.html.description}` } }
+        dangerouslySetInnerHTML={ { __html: `${snippet.description}` } }
       />
     </Card>
   </Anchor>

--- a/src/molecules/previewCard/previewCard.test.jsx
+++ b/src/molecules/previewCard/previewCard.test.jsx
@@ -10,15 +10,10 @@ console.warn = jest.fn();
 describe('<PreviewCard />', () => {
   const snippet = {
     title: 'compose',
-    language: {
-      long: 'JavaScript',
-      short: 'js',
-    },
+    language: 'JavaScript',
     primaryTag: 'function',
     expertise: 'intermediate',
-    html: {
-      description: '<p>Performs right-to-left function composition.</p>',
-    },
+    description: '<p>Performs right-to-left function composition.</p>',
     url: 'snippets/compose',
   };
   let wrapper, card, expertise, anchor;
@@ -63,7 +58,7 @@ describe('<PreviewCard />', () => {
   });
 
   it('should render the correct description', () => {
-    expect(card.find('.card-description').html()).toContain(snippet.html.description);
+    expect(card.find('.card-description').html()).toContain(snippet.description);
   });
 
   it('should link to the correct url', () => {

--- a/src/organisms/recommendationList/recommendationList.test.jsx
+++ b/src/organisms/recommendationList/recommendationList.test.jsx
@@ -11,15 +11,10 @@ describe('<RecommendationList />', () => {
   const snippetList = [
     {
       title: 'compose',
-      language: {
-        long: 'JavaScript',
-        short: 'js',
-      },
+      language: 'JavaScript',
       primaryTag: 'function',
       expertise: 'intermediate',
-      html: {
-        description: '<p>Performs right-to-left function composition.</p>',
-      },
+      description: '<p>Performs right-to-left function composition.</p>',
       url: 'snippets/compose',
     },
   ];

--- a/src/organisms/snippetList/snippetList.test.jsx
+++ b/src/organisms/snippetList/snippetList.test.jsx
@@ -16,15 +16,10 @@ describe('<SnippetList />', () => {
   const snippetList = [
     {
       title: 'compose',
-      language: {
-        long: 'JavaScript',
-        short: 'js',
-      },
+      language: 'JavaScript',
       primaryTag: 'function',
       expertise: 'intermediate',
-      html: {
-        description: '<p>Performs right-to-left function composition.</p>',
-      },
+      description: '<p>Performs right-to-left function composition.</p>',
       url: 'snippets/compose',
     },
   ];

--- a/src/queries/getSearchIndex.js
+++ b/src/queries/getSearchIndex.js
@@ -15,7 +15,6 @@ export default `
         }
         expertise
         language {
-          short
           long
         }
         searchTokens

--- a/src/templates/listingPage/listingPage.test.jsx
+++ b/src/templates/listingPage/listingPage.test.jsx
@@ -22,15 +22,10 @@ describe('<ListingPage />', () => {
   const snippetList = [
     {
       title: 'compose',
-      language: {
-        long: 'JavaScript',
-        short: 'js',
-      },
+      language: 'JavaScript',
       primaryTag: 'function',
       expertise: 'intermediate',
-      html: {
-        description: '<p>Performs right-to-left function composition.</p>',
-      },
+      description: '<p>Performs right-to-left function composition.</p>',
       url: 'snippets/compose',
     },
   ];

--- a/src/typedefs/language.js
+++ b/src/typedefs/language.js
@@ -1,16 +1,19 @@
-import { shape, string, arrayOf } from 'prop-types';
+import { shape, string, arrayOf, oneOfType } from 'prop-types';
 
 const langShape = {
   short: string,
   long: string,
 };
 
-const Language = shape({
-  ...langShape,
-  otherLanguages: arrayOf(
-    shape({...langShape})
-  ),
-});
+const Language = oneOfType([
+  string,
+  shape({
+    ...langShape,
+    otherLanguages: arrayOf(
+      shape({...langShape})
+    ),
+  }),
+]);
 
 Language.toString = () => `
 type SimpleLanguageData @infer {

--- a/src/typedefs/snippet.js
+++ b/src/typedefs/snippet.js
@@ -11,10 +11,11 @@ const Snippet = shape({
   title: string,
   expertise: oneOf(EXPERTISE_LEVELS),
   tags: Tags,
-  languge: Language,
+  language: Language,
   code: Code,
   html: Html,
   url: string,
+  description: string,
 });
 
 Snippet.toString = () => `


### PR DESCRIPTION
There were multiple issues slowing down both builds and the website itself. Namely:

- `gatsby-transformer-json` plugin was redundant.
- Source maps were being generated in production.
- There was a bug with `</p>` being cropped in some snippet descriptions, which would cause some slowdowns or even errors.
- Preview card data had a maximum depth of 2, which would slow performance and create additional data that was not necessary.

The performance and size metrics before and after the changes are as follows:

|Metric|Value before|Value after|Gain|
|---|---|---|---|
|Directory size| 70.6MB | 63.5MB| 9% |
|Build speed (Gatsby/Production)|59s|47s|8%|
|Performance rating (Lighthouse)|94|98|4%|
|Speed Index| 2.6s|2.0s|30%|
|Main thread work|3.0s|2.6s|15%|

