### PR TITLE
Reduce number of font resources

### DIFF
--- a/src/atoms/anchor/linkBackAnchor/_index.scss
+++ b/src/atoms/anchor/linkBackAnchor/_index.scss
@@ -5,7 +5,6 @@ a.link-back {
   line-height: 1.35;
   display: block;
   margin: 0.8125rem 1.25rem 1.5rem;
-  font-weight: 500;
   padding-left: 24px;
   background-image: generate-icon-background("arrow-left", $fore-color-dark-light, 'none', 2, 20);
   background-position: 0 center;

--- a/src/atoms/button/regularButton/_index.scss
+++ b/src/atoms/button/regularButton/_index.scss
@@ -20,7 +20,6 @@ $button-fore-color: #FFFFFF;
   cursor: pointer;
   border: none;
   border-radius: 1rem;
-  font-weight: 500;
   font-size: 1.125rem;
   line-height: 1.4;
   transition: 0.3s ease all;

--- a/src/atoms/card/_index.scss
+++ b/src/atoms/card/_index.scss
@@ -36,7 +36,6 @@
   .card-title {
     font-size: 1.25rem;
     line-height: 1.75rem;
-    font-weight: 500;
     margin: 0.625rem 0.5rem 0.125rem;
     transition: 0.3s ease all;
     color: var(--card-fore-color);
@@ -47,7 +46,6 @@
     font-size: 0.875rem;
     color: var(--card-fore-color-light);
     line-height: 1.35;
-    font-weight: 500;
     
     > p {
       margin: 0.8125rem 0.5rem 1.5rem;

--- a/src/organisms/shell/_index.scss
+++ b/src/organisms/shell/_index.scss
@@ -62,7 +62,6 @@ h1.website-title {
   transition: 0.3s ease all;
   font-size: 1rem;
   line-height: 1.375;
-  font-weight: 500;
   > a {
     &, &:link, &:visited {
       color: var(--fore-color-lighter);

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -33,14 +33,6 @@
 }
 @font-face {
   font-family: 'Noto Sans';
-  font-style: italic;
-  font-weight: 300;
-  font-display: swap;
-  src: local('Noto Sans LightItalic'), local('NotoSans-LightItalic'), url(../assets/NotoSans-LightItalic.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-@font-face {
-  font-family: 'Noto Sans';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
@@ -58,32 +50,8 @@
 @font-face {
   font-family: 'Noto Sans';
   font-style: normal;
-  font-weight: 500;
-  font-display: swap;
-  src: local('Noto Sans Medium'), local('NotoSans-Medium'), url(../assets/NotoSans-Medium.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-@font-face {
-  font-family: 'Noto Sans';
-  font-style: italic;
-  font-weight: 500;
-  font-display: swap;
-  src: local('Noto Sans Medium Italic'), local('NotoSans-MediumItalic'), url(../assets/NotoSans-MediumItalic.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-@font-face {
-  font-family: 'Noto Sans';
-  font-style: normal;
   font-weight: 600;
   font-display: swap;
   src: local('Noto Sans SemiBold'), local('NotoSans-SemiBold'), url(../assets/NotoSans-SemiBold.woff2) format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-@font-face {
-  font-family: 'Noto Sans';
-  font-style: italic;
-  font-weight: 600;
-  font-display: swap;
-  src: local('Noto Sans SemiBold Italic'), local('NotoSans-SemiBoldItalic'), url(../assets/NotoSans-SemiBoldItalic.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
Resolves #31.
Remove Noto Sans Light Italic (300 italic).
Remove Noto Sans Medium (500) and Medium Italic (500 italic).
Remove Noto Sans SemiBold Italic (600 italic).
Update font usage to match removals.
Affects multiple styles across components.

Old fonts are still in the `assets` directory shall we need to use them in the future.