### PR TITLE
Update search history functionality

### DIFF
--- a/src/atoms/search/index.jsx
+++ b/src/atoms/search/index.jsx
@@ -35,17 +35,22 @@ const Search = ({
   searchIndex,
   searchQuery,
   shouldUpdateHistory = false,
+  searchTimestamp,
   dispatch,
 }) => {
-  const [value, setValue] = React.useState(searchQuery);
+  const [value, setValue] = React.useState('');
 
   useFetchSearchIndex(dispatch);
 
   React.useEffect(() => {
     if (shouldUpdateHistory) {
       const params = getURLParameters(window.location.href);
-      if (params && (params.keyphrase || params.keyphrase === '') && params.keyphrase !== encodeURIComponent(searchQuery))
-        setValue(decodeURIComponent(params.keyphrase));
+      let initValue = searchQuery;
+      if (params && (params.keyphrase) && params.keyphrase !== encodeURIComponent(searchQuery))
+        initValue = decodeURIComponent(params.keyphrase);
+      else if(searchTimestamp && new Date() - new Date(searchTimestamp || null) >= 1200000)
+        initValue = '';
+      setValue(initValue);
     }
   }, []);
 
@@ -58,7 +63,7 @@ const Search = ({
 
   return (
     <input
-      defaultValue={ searchQuery }
+      defaultValue={ value }
       className={ trimWhiteSpace`search-box ${className}` }
       type='search'
       id={ id }
@@ -86,6 +91,8 @@ Search.propTypes = {
   searchQuery: PropTypes.string,
   /** Index of the searchable data */
   searchIndex: PropTypes.arrayOf(PropTypes.shape({})),
+  /** Timestamp of the last search history update */
+  searchTimestamp: PropTypes.string,
   /** Additional classname(s) for the search bar */
   className: PropTypes.string,
   /** Element id */
@@ -100,6 +107,7 @@ export default connect(
   state => ({
     searchIndex: state.search.searchIndex,
     searchQuery: state.search.searchQuery,
+    searchTimestamp: state.search.searchTimestamp,
   }),
   null
 )(Search);

--- a/src/state/search.js
+++ b/src/state/search.js
@@ -6,6 +6,7 @@ const initialState = {
   searchQuery: '',
   searchIndex: [],
   searchResults: [],
+  searchTimestamp: `${new Date()}`,
 };
 
 // Actions
@@ -58,6 +59,7 @@ export default (state = initialState, action) => {
   case PUSH_NEW_QUERY:
     return {
       ...state,
+      searchTimestamp: `${new Date()}`,
       searchQuery: action.query,
     };
   case START_INDEX_FETCH:


### PR DESCRIPTION
Due to the way search history and state have been implemented, there are a few issues with the current funcionality. This PR addresses said issues (i.e. forever persisting search queries and keyphrase links not updating the search query and results), by doing the following:

- Introduced a new state variable under `search`: `searchTimestamp`. This helps keep track of the last time the user queried the search engine and handle state accordingly.
- Automatically update `searchTimestamp` whenever a new query is sent.
- Handle search timeout (20 minutes).
- Handle inbound traffic from `?keyphrase=...` links to update state with the keyphrase instead of the existing query.
- Ensure that the `Search` atom's `value` state variable will always be in sync with  `searchQuery` from Redux, handle `defaultValue` appropriately.
- Use the initial `useEffect()` hook in `Search` atom to handle initialization of `value`. Every time the `value` state variable is updated, the Redux store gets updated, which means rendering a new `Search` atom will bump the `searchTimestamp` effectively extending the search session duration.