### PR TITLE
Remove JS Adapter tag, redirect listing page

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -15,6 +15,13 @@
 /php                                   /php/p/1                                 301!
 
 # -----------------------------------------------------------------------------
+#   UPDATED TAG REDIRECTS:
+#
+# * Redirect JS Adapter to Function after mergin - 13/01/2020
+# -----------------------------------------------------------------------------
+js/t/adapter/p/1/                      /js/t/function/p/1                       301!
+
+# -----------------------------------------------------------------------------
 #   LEGACY REDIRECTS:
 #
 # * Redirect old JS website routes to new pages


### PR DESCRIPTION
Deployment to redirect `Adapter` JS tag to `Function`. 
Merge after [30-seconds/30-seconds-of-code#1074](https://github.com/30-seconds/30-seconds-of-code/pull/1074) is built.