### PR TITLE
Enable unlisted listings, decouple from archive

### DIFF
--- a/content/configs/30codeArchive.js
+++ b/content/configs/30codeArchive.js
@@ -6,9 +6,10 @@ export default {
   requirables: [
     'snippet_data/archivedSnippets.json',
   ],
-  slug: 'js',
+  slug: 'js/a',
   reducer: 'es6Reducer',
   isArchived: true,
+  isUnlisted: true,
   biasPenaltyMultiplier: -1.0,
   tagScores: {
   },

--- a/src/functions/build/createPages/createListingPages.js
+++ b/src/functions/build/createPages/createListingPages.js
@@ -24,7 +24,7 @@ const createAllListingPages = (searchIndex, listingMetas, listingPage, createPag
   // Create listing pages for the main listing
   const searchIndexChunks = chunk(transformSnippetIndex(searchIndex.edges), 20);
   const mainListingSublinks = listingMetas
-    .filter(v => !v.archived)
+    .filter(v => !v.unlisted)
     .map(v => v.featured > 0 ? v : {...v, featured: 500 })
     .sort((a, b) => a.featured - b.featured);
 

--- a/src/functions/parsers/parseListingMetas.js
+++ b/src/functions/parsers/parseListingMetas.js
@@ -6,6 +6,7 @@ const parseListingMetas = requirables =>
     .map(rq => ({
       featured: rq.meta.featured,
       archived: rq.meta.archived,
+      unlisted: rq.meta.unlisted,
       link: {
         internal: true,
         url: `/${rq.meta.slugPrefix.slice(0, rq.meta.slugPrefix.indexOf('/'))}/p/1`,

--- a/src/functions/parsers/parseRequirables.js
+++ b/src/functions/parsers/parseRequirables.js
@@ -31,6 +31,9 @@ const parseRequirables = contentDirPath => {
         reqJson.meta.archived = archived;
         reqJson.meta.slugPrefix = archived ? `${cfg.slug}/v` : `${cfg.slug}/s`;
 
+        const unlisted = !!cfg.isUnlisted;
+        reqJson.meta.unlisted = unlisted;
+
         reqJson.meta.sourceDir = `${cfg.dirName}/${cfg.snippetPath}`;
         reqJson.meta.repoUrlPrefix = `${cfg.repoUrl}/blob/master/${cfg.snippetPath}`;
 


### PR DESCRIPTION
Resolves #52
Blocks #33 

### Changelog

- Allow configurations to specify the `isUnlisted` field.
- Use field to instantiate the `unlisted` property.
- Parse appropriately in listing metadata.
- Unlisted listings will not be displayed in listing anchors.
- Archived listings will be displayed in listing anchors.
- Archived listings need to explicitly specify they are unlisted.
- Specify an alternative slug in the JS archive config.
- Explicitly specify `isUnlisted: true` in the JS archive config.

### Deployment

- Before #33, after #54 
