### PR TITLE
Listing pagination revamp

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -19,8 +19,10 @@ const onPreRouteUpdate = ({ location, prevLocation }) => {
 
 const onRouteUpdate = ({ location, prevLocation }) => {
   try {
-    if (locationScrollTops[location.pathname])
+    if (locationScrollTops[location.pathname] && prevLocation.includes('/s/'))
       document.querySelector('.content').scrollTop = locationScrollTops[location.pathname];
+    else if(location.pathname.match(/\/[ape]\/\d+/) && prevLocation.pathname.match(/\/[ape]\/\d+/))
+      document.querySelector('.content').scrollTop = 0;
 
   } catch (e) { return; }
 

--- a/src/functions/build/createPages/createListingPages.js
+++ b/src/functions/build/createPages/createListingPages.js
@@ -10,6 +10,8 @@ const ORDERS_MAP = {
   'e': _l('orders.expertise'),
 };
 
+const CARDS_PER_PAGE = 40;
+
 const createListingPages = (
   indexedChunks, listingPage, createPage, context, baseUrl, slugOrderingSegment, ordersList
 ) => {
@@ -86,13 +88,13 @@ const createListingPagesWithOrderOptions = (
 const createAllListingPages = (searchIndex, listingMetas, listingPage, createPage, context) => {
   // Create listing pages for the main listing
   const transformedIndex = transformSnippetIndex(searchIndex.edges);
-  const popularChunks = chunk(transformedIndex, 20);
-  const alphabeticalChunks = chunk(transformedIndex.sort((a, b) => a.title.localeCompare(b.title)), 20);
+  const popularChunks = chunk(transformedIndex, CARDS_PER_PAGE);
+  const alphabeticalChunks = chunk(transformedIndex.sort((a, b) => a.title.localeCompare(b.title)), CARDS_PER_PAGE);
   const expertiseChunks = chunk(transformedIndex.sort((a, b) =>
     a.expertise === b.expertise ? a.title.localeCompare(b.title) :
       !a.expertise ? 1 : !b.expertise ? -1 :
         EXPERTISE_LEVELS.indexOf(a.expertise) - EXPERTISE_LEVELS.indexOf(b.expertise)
-  ), 20);
+  ), CARDS_PER_PAGE);
   const mainListingSublinks = listingMetas
     .filter(v => !v.unlisted)
     .map(v => v.featured > 0 ? v : {...v, featured: 500 })
@@ -136,13 +138,13 @@ const createAllListingPages = (searchIndex, listingMetas, listingPage, createPag
         (s.node.blog && s.node.tags.all.find(t => t.toLowerCase() === searchIndexName.toLowerCase()))
       );
       const transformedSlugChunks = transformSnippetIndex(searchIndexSlugData);
-      const popularSlugChunks = chunk(transformedSlugChunks, 20);
-      const alphabeticalSlugChunks = chunk(transformedSlugChunks.sort((a, b) => a.title.localeCompare(b.title)), 20);
+      const popularSlugChunks = chunk(transformedSlugChunks, CARDS_PER_PAGE);
+      const alphabeticalSlugChunks = chunk(transformedSlugChunks.sort((a, b) => a.title.localeCompare(b.title)), CARDS_PER_PAGE);
       const expertiseSlugChunks = chunk(transformedSlugChunks.sort((a, b) =>
         a.expertise === b.expertise ? a.title.localeCompare(b.title) :
           !a.expertise ? 1 : !b.expertise ? -1 :
             EXPERTISE_LEVELS.indexOf(a.expertise) - EXPERTISE_LEVELS.indexOf(b.expertise)
-      ), 20);
+      ), CARDS_PER_PAGE);
       const searchIndexTagPrefixes = listingMeta.tags;
       const slugContextCustomizer = order => {
         return {
@@ -194,13 +196,13 @@ const createAllListingPages = (searchIndex, listingMetas, listingPage, createPag
             )
           );
         const transformedTagChunks = transformSnippetIndex(searchIndexTagData);
-        const popularTagChunks = chunk(transformedTagChunks, 20);
-        const alphabeticalTagChunks = chunk(transformedTagChunks.sort((a, b) => a.title.localeCompare(b.title)), 20);
+        const popularTagChunks = chunk(transformedTagChunks, CARDS_PER_PAGE);
+        const alphabeticalTagChunks = chunk(transformedTagChunks.sort((a, b) => a.title.localeCompare(b.title)), CARDS_PER_PAGE);
         const expertiseTagChunks = chunk(transformedTagChunks.sort((a, b) =>
           a.expertise === b.expertise ? a.title.localeCompare(b.title) :
             !a.expertise ? 1 : !b.expertise ? -1 :
               EXPERTISE_LEVELS.indexOf(a.expertise) - EXPERTISE_LEVELS.indexOf(b.expertise)
-        ), 20);
+        ), CARDS_PER_PAGE);
         const tagContextCustomizer = order => {
           return {
             listingSublinks: listingMeta.blog ? [] : [

--- a/src/molecules/paginator/_index.scss
+++ b/src/molecules/paginator/_index.scss
@@ -29,101 +29,56 @@ $paginator-selected-color-dark: #B0C3E3;
 
   .btn, a.btn {
     transition: 0.3s ease all;
-    flex: 1;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
+    font-size: 1.125rem;
     margin: 0.25rem 0;
-    padding: 0.625rem 1.125rem;
+    padding: 0.625rem 0;
     box-sizing: border-box;
-    line-height: 1.25;
+    line-height: 24px;
     height: 44px;
     min-width: 44px;
     text-align: center;
-
-    border-radius: 0;
-    border-bottom: 1px solid var(--back-color-dark);  
     box-shadow: none;
     background: transparent;
     font-size: 1.125rem;
-    
-    @media screen and (min-width: $layout-medium-breakpoint) {
-      margin: 0.5rem 0;
-      padding: 0.625rem 1.375rem;
-    }
+    color: var(--fore-color);
 
     &:not(.current-page) {
-      color: var(--fore-color);
+
       &:hover, &:focus {
         color: var(--paginator-selected-color);
-        border-bottom: 1px solid var(--paginator-selected-color);  
       }
     }
 
+    &.current-page {
+      cursor: default;
+      font-size: 1.5rem;
+    }
+
     &.previous-page, &.next-page {
+      color: var(--paginator-selected-color);
       position: relative;
-      flex: 2;
-      width: 44px;
+      width: 52px;
       box-sizing: border-box;
 
       &:before {
         position: absolute;
-        font-size: 24px;
+        font-size: 28px;
         width: 100%;
         text-align: center;
-      }
-    
-      @media screen and (min-width: $layout-medium-breakpoint) {
-        width: auto;
-
-        &:before {
-          width: auto;
-        }
-      }
-    }
-
-    &.previous-page {
-      &:before {
         left: 0;
-      }
-
-      @media screen and (min-width: $layout-medium-breakpoint) {
-        padding-left: 32px;
-
-        &:before {
-          left: 6px;
-        }
+        top: 0;
+        line-height: 44px;
       }
     }
 
-    &.next-page {
-      &:before {
-        right: 0;
-      }
-      @media screen and (min-width: $layout-medium-breakpoint) {
-        padding-right: 32px;
-
-        &:before {
-          right: 6px;
-        }
-      }
-    }
-  }
-
-  .btn.current-page {
-    cursor: default;
-    color: var(--paginator-selected-color);
-    line-height: 1px;
   }
 
   .paginator-separator {
-    display: none;
+    display: block;
     color: var(--fore-color-lighter);
+    opacity: 0.45;
     letter-spacing: 2px;
-    line-height: 2.625rem;
-    border-bottom: 1px solid var(--back-color-dark); 
-    
-    @media screen and (min-width: $layout-medium-breakpoint) {
-      display: block;
-    }
+    line-height: 24px;
+    font-size: 1.5rem;
   }
 }

--- a/src/molecules/paginator/index.jsx
+++ b/src/molecules/paginator/index.jsx
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import { trimWhiteSpace } from 'functions/utils';
 import { AnchorButton, Button } from 'atoms/button';
 import { Paginator as PaginatorPropType } from 'typedefs';
-import { useMedia } from 'functions/hooks';
-import _ from 'lang';
-const _l = _('en');
 
 /**
  * Renders a pagination component (responsively).
@@ -23,49 +20,26 @@ const Paginator = ({
 }) => {
   if (totalPages <= 1) return null;
 
-  const buttonTexts = useMedia(
-    ['(max-width: 600px'],
-    [['\u200b', '\u200b']],
-    [_l('Previous'), _l('Next')]
-  );
-
-  const showAllButtons = useMedia(
-    ['(max-width: 420px'],
-    [false],
-    true
-  );
-
   /*
-    Up to 5 buttons (apart from next and previous):
-    - page 1: 1,2,3,4,...{totalPages}
-    - page 2: 1,2,3,4....{totalPages}
-    - page 3: 1...3,4,5....{totalPages}
-    - page X: 1,... X-1,X,X+1,...{totalPages}
-    - page {totalPages-2}: 1,...{totalPages-5},{totalPages-4},{totalPages-3}...{totalPages}
-    - page {totalPages-1}: 1,...{totalPages-3},{totalPages-2},{totalPages-1},{totalPages}
-    - page {totalPages}: 1,...{totalPages-3},{totalPages-2},{totalPages-1},{totalPages}
-    - totalPages < 5: all
+    Up to 3 buttons (apart from next and previous):
+    - page 1: 1,2,...{totalPages}
+    - page 2: 1,2....{totalPages}
+    - page 3: 1...3....{totalPages}
+    - page X: 1,... X...{totalPages}
+    - page {totalPages-2}: 1,...{totalPages-2}...{totalPages}
+    - page {totalPages-1}: 1,...{totalPages-1},{totalPages}
+    - page {totalPages}: 1,...{totalPages-1},{totalPages}
+    - totalPages < 3: all
   */
   let buttons = [];
-  if (showAllButtons) {
-    if (totalPages <= 5)
-      buttons = Array.from({ length: totalPages }, (v, i) => i + 1);
-    else if (pageNumber <= 2)
-      buttons = [1, 2, 3, 4, '...', totalPages];
-    else if (totalPages - pageNumber <= 2)
-      buttons = [1, '...', totalPages - 3, totalPages - 2, totalPages - 1, totalPages];
-    else
-      buttons = [1, '...', pageNumber - 1, pageNumber, pageNumber + 1, '...', totalPages];
-  } else {
-    if (totalPages <= 3)
-      buttons = Array.from({ length: totalPages }, (v, i) => i + 1);
-    else if (pageNumber <= 2)
-      buttons = [1, 2, totalPages];
-    else if (totalPages - pageNumber <= 2)
-      buttons = [1, totalPages - 1, totalPages];
-    else
-      buttons = [1, pageNumber, totalPages];
-  }
+  if (totalPages <= 3)
+    buttons = Array.from({ length: totalPages }, (v, i) => i + 1);
+  else if (pageNumber <= 2)
+    buttons = [1, 2, '...', totalPages];
+  else if (totalPages - pageNumber <= 2)
+    buttons = [1, '...', totalPages - 1, totalPages];
+  else
+    buttons = [1, '...', pageNumber, '...', totalPages];
 
   return (
     <div
@@ -78,7 +52,7 @@ const Paginator = ({
           internal: true,
           url: `${baseUrl}/${slugOrderingSegment}/${pageNumber - 1}`,
         } }>
-        { buttonTexts[0] }
+        { '\u200b' }
       </AnchorButton> }
       {
         buttons.map((buttonNumber, i) => (
@@ -87,7 +61,7 @@ const Paginator = ({
               className='paginator-separator'
               key={ `sep-${i}` }
             >
-              { _l('...') }
+              { buttonNumber }
             </span> :
             buttonNumber === pageNumber ?
               <Button
@@ -114,7 +88,7 @@ const Paginator = ({
           internal: true,
           url: `${baseUrl}/${slugOrderingSegment}/${pageNumber + 1}`,
         } }>
-        { buttonTexts[1] }
+        { '\u200b' }
       </AnchorButton> }
     </div>
   );

--- a/src/molecules/paginator/paginator.test.jsx
+++ b/src/molecules/paginator/paginator.test.jsx
@@ -34,21 +34,6 @@ describe('<Paginator />', () => {
     });
   });
 
-  describe('with fewer than 5 pages', () => {
-    beforeEach(() => {
-      wrapper = mount(
-        <Paginator paginator={ {
-          pageNumber,
-          totalPages: 4,
-          baseUrl,
-        } } />);
-    });
-
-    it('should render the correct amount of buttons', () => {
-      expect(wrapper).toContainMatchingElements(5, 'a.btn');
-    });
-  });
-
   describe('with first page as current', () => {
     beforeEach(() => {
       wrapper = mount(
@@ -65,7 +50,7 @@ describe('<Paginator />', () => {
       });
 
       it('appropriate buttons for next and other pages', () => {
-        expect(wrapper).toContainMatchingElements(5, 'a.btn');
+        expect(wrapper).toContainMatchingElements(3, 'a.btn');
       });
     });
   });
@@ -86,7 +71,7 @@ describe('<Paginator />', () => {
       });
 
       it('appropriate buttons for next and other pages', () => {
-        expect(wrapper).toContainMatchingElements(5, 'a.btn');
+        expect(wrapper).toContainMatchingElements(3, 'a.btn');
       });
     });
   });

--- a/src/organisms/cta/_index.scss
+++ b/src/organisms/cta/_index.scss
@@ -25,6 +25,7 @@
     background-size: 120px, 120px;
     width: 120px;
     left: 1.25rem;
+    height: 120px;
     background-position-x: left;
 
     @media screen and (max-width: calc(#{$layout-medium-breakpoint} - 1px)) {

--- a/src/organisms/shell/index.jsx
+++ b/src/organisms/shell/index.jsx
@@ -13,6 +13,7 @@ import env from '../../../.build/env';
 const Shell = ({
   isDarkMode,
   acceptsCookies,
+  isBot,
   isSearch = false,
   isSettings = false,
   dispatch,
@@ -26,7 +27,7 @@ const Shell = ({
       className={ trimWhiteSpace`page-container ${isDarkMode ? 'dark' : ''}` }
     >
       {
-        typeof acceptsCookies === 'undefined' && env === 'PRODUCTION' ?
+        typeof acceptsCookies === 'undefined' && env === 'PRODUCTION' && !isBot ?
           <CookieConsentPopup
             onAccept={ e => {
               e.preventDefault();
@@ -71,6 +72,8 @@ Shell.propTypes = {
   isDarkMode: PropTypes.bool,
   /** Does the user accept cookies? */
   acceptsCookies: PropTypes.bool,
+  /** Is the client a bot? (Auto-detect) */
+  isBot: PropTypes.bool,
   /** Is this a search page? */
   isSearch: PropTypes.bool,
   /** Is this a search page? */
@@ -90,6 +93,7 @@ export default connect(
     isDarkMode: state.shell.isDarkMode,
     lastPageUrl: state.navigation.lastPageUrl,
     acceptsCookies: state.shell.acceptsCookies,
+    isBot: state.shell.isBot,
   }),
   null
 )(Shell);

--- a/src/organisms/snippetList/index.jsx
+++ b/src/organisms/snippetList/index.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import Paginator from 'molecules/paginator';
 import Sorter from 'molecules/sorter';
 import PageTitle from 'atoms/pageTitle';
 import PageSubtitle from 'atoms/pageSubtitle';
 import PreviewCard from 'molecules/previewCard';
+import CTA from 'organisms/cta';
 import ListingAnchors from 'molecules/listingAnchors';
 import {
   Snippet as SnippetPropType,
@@ -21,7 +23,11 @@ const SnippetList = ({
   listingName,
   listingType,
   listingSublinks = [],
+  acceptsCookies,
 }) => {
+  const ctaIndex = snippetList.length > 20
+    ? Math.floor(snippetList.length * 0.55)
+    : snippetList.length - 1;
   return snippetList.length ? (
     <>
       {
@@ -33,12 +39,22 @@ const SnippetList = ({
         { listingName }
       </PageTitle>
       <Sorter sorter={ sorter } />
-      { snippetList.map(snippet => (
-        <PreviewCard
-          key={ `snippet_${snippet.url}` }
-          snippet={ snippet }
-          context={ listingType }
-        />
+      { snippetList.map((snippet, i) => (
+        <>
+          <PreviewCard
+            key={ `snippet_${snippet.url}` }
+            snippet={ snippet }
+            context={ listingType }
+          />
+          {
+            i === ctaIndex ?
+              <CTA
+                onlySocial
+                acceptsCookies={ acceptsCookies }
+              />
+              : null
+          }
+        </>
       )) }
       <Paginator paginator={ paginator } />
     </>
@@ -58,6 +74,13 @@ SnippetList.propTypes = {
   listingType: PropTypes.string,
   /** Links to sublists */
   listingSublinks: PropTypes.arrayOf(PropTypes.shape({})),
+  /** Does the user accept cookies? */
+  acceptsCookies: PropTypes.bool,
 };
 
-export default SnippetList;
+export default connect(
+  state => ({
+    acceptsCookies: state.shell.acceptsCookies,
+  }),
+  null
+)(SnippetList);

--- a/src/organisms/snippetList/snippetList.test.jsx
+++ b/src/organisms/snippetList/snippetList.test.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Provider } from 'react-redux';
+import createStore from 'state';
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
@@ -6,6 +8,8 @@ import SnippetList from './index';
 
 configure({ adapter: new Adapter() });
 console.warn = jest.fn();
+
+const { store } = createStore();
 
 describe('<SnippetList />', () => {
   const paginator = {
@@ -36,12 +40,14 @@ describe('<SnippetList />', () => {
 
   beforeEach(() => {
     wrapper = mount(
-      <SnippetList
-        snippetList={ snippetList }
-        paginator={ paginator }
-        sorter={ sorter }
-        listingName={ listingName }
-      />
+      <Provider store={ store }>
+        <SnippetList
+          snippetList={ snippetList }
+          paginator={ paginator }
+          sorter={ sorter }
+          listingName={ listingName }
+        />
+      </Provider>
     );
     pageTitle = wrapper.find('PageTitle');
     paginate = wrapper.find('Paginator');

--- a/src/state/shell.js
+++ b/src/state/shell.js
@@ -1,11 +1,18 @@
 import cacheKey from '../../.build/cacheKey';
 
+/** Checks if the client is a bot */
+const isBot = () =>
+  typeof navigator !== 'undefined' &&
+  typeof navigator.userAgent !== 'undefined' &&
+  /bot|google|baidu|bing|msn|duckduckbot|teoma|slurp|yandex/i.test(navigator.userAgent);
+
 // Default state
 const initialState = {
   isDarkMode: undefined,
   hasGithubLinksEnabled: undefined,
   cacheKey,
   newCacheKey: cacheKey,
+  isBot: isBot(),
   acceptsCookies: undefined,
 };
 
@@ -60,5 +67,5 @@ export default (state = initialState, action) => {
 // Persistence configuration
 export const persistConfig = {
   key: 'shell',
-  blacklist: ['newCacheKey'],
+  blacklist: ['newCacheKey', 'isBot'],
 };


### PR DESCRIPTION
![Screenshot from 2020-03-05 10-19-44](https://user-images.githubusercontent.com/8281875/75961551-e4029280-5eca-11ea-927c-84f40e660ffb.png)

- Resolves #82.
- Decrease paginator page options from 5 to 3 (not including previous and next buttons).
- Highlight current page more prominently.
- Scroll to top when navigating to a new page via paginator.
- Only store the scroll position when navigating away from a listing to a snippet (or only restore it when coming back).
- Increase preview cards per listing page from 20 to 40, which seems to be a sweet spot for all devices.
- Add a CTA for Twitter halfway-ish through a list page.
- Handle bots appropriately (from previous research and testing, do not send page views and do not show the cookie disclaimer etc.).