### PR TITLE
Remove SnippetCard HOC

### DIFF
--- a/src/build/createPages/index.js
+++ b/src/build/createPages/index.js
@@ -85,7 +85,7 @@ const createPages = (query, templates, requirables) => ({ graphql, actions }) =>
         createPage,
         {
           ...commonContext,
-          cardTemplate: 'standard',
+          cardTemplate: 'StandardSnippetCard',
         },
         allSnippets
       );
@@ -96,7 +96,7 @@ const createPages = (query, templates, requirables) => ({ graphql, actions }) =>
         createPage,
         {
           ...commonContext,
-          cardTemplate: 'css',
+          cardTemplate: 'CssSnippetCard',
         },
         allSnippets
       );
@@ -107,7 +107,7 @@ const createPages = (query, templates, requirables) => ({ graphql, actions }) =>
         createPage,
         {
           ...commonContext,
-          cardTemplate: 'blog',
+          cardTemplate: 'BlogSnippetCard',
         },
         allSnippets,
         result.data.images.edges

--- a/src/build/transformers/transformBreadcrumbs.js
+++ b/src/build/transformers/transformBreadcrumbs.js
@@ -13,11 +13,11 @@ export const transformBreadcrumbs = (snippet, cardTemplate) => {
         internal: true,
         url: `/${slugParts[0]}/p/1`,
       },
-      name: cardTemplate === 'blog' ? transformTagName('blog') : snippet.language.long,
+      name: cardTemplate === 'BlogSnippetCard' ? transformTagName('blog') : snippet.language.long,
     },
   ];
 
-  if(cardTemplate !== 'blog') {
+  if(cardTemplate !== 'BlogSnippetCard') {
     breadcrumbs.push({
       link: {
         internal: true,

--- a/src/build/transformers/transformBreadcrumbs.test.js
+++ b/src/build/transformers/transformBreadcrumbs.test.js
@@ -3,14 +3,14 @@ import { fullSnippet, fullBlogSnippet } from 'fixtures/snippets';
 
 describe('transformBreadcrumbs', () => {
   it('should produce the appropriate breadcrumbs for a normal snippet', () => {
-    const breadcrumbs = transformBreadcrumbs(fullSnippet, 'standard');
+    const breadcrumbs = transformBreadcrumbs(fullSnippet, 'StandardSnippetCard');
     expect(breadcrumbs).toEqual([
       { link: { internal: true, url: '/js/p/1'}, name: 'JavaScript' },
       { link: { internal: true, url: '/js/string/p/1' }, name: 'JavaScript String'},
     ]);
   });
   it('should produce the appropriate breadcrumbs for a blog snippet', () => {
-    const breadcrumbs = transformBreadcrumbs(fullBlogSnippet, 'blog');
+    const breadcrumbs = transformBreadcrumbs(fullBlogSnippet, 'BlogSnippetCard');
     expect(breadcrumbs).toEqual([
       { link: { internal: true, url: '/blog/p/1'}, name: 'Blog' },
     ]);

--- a/src/build/transformers/transformSnippets.js
+++ b/src/build/transformers/transformSnippets.js
@@ -28,7 +28,7 @@ export const transformSnippetIndex = (edges, withSearchTokens = false) =>
  */
 export const transformSnippetDescription = (snippet, cardTemplate) => {
   const parsedDescription = stripMarkdownFormat(snippet.text.short);
-  return cardTemplate === 'blog' || parsedDescription.length <= 160
+  return cardTemplate === 'BlogSnippetCard' || parsedDescription.length <= 160
     ? parsedDescription
     : literals.pageDescription(snippet.title, snippet.language.long);
 };
@@ -50,7 +50,7 @@ export const transformSnippetContext = (snippet, cardTemplate, imageContext) => 
   let templateProps = {};
   let html = snippet.html;
   switch (cardTemplate) {
-  case 'blog':
+  case 'BlogSnippetCard':
     templateProps = {
       authors: snippet.authors,
       type: snippet.blogType,

--- a/src/build/transformers/transformSnippets.test.js
+++ b/src/build/transformers/transformSnippets.test.js
@@ -136,7 +136,7 @@ describe('transformSnippetContext', () => {
     const result = transformSnippetContext({
       ...snippet, authors: ['a', 'b'], blogType: 'blog.story', cover: 'img.png',
       html: { fullDescription: '<p><img src="./img.png"></p>'},
-    }, 'blog', [{
+    }, 'BlogSnippetCard', [{
       node: { absolutePath: 'img.png', childImageSharp: { fluid: { src: 'xxx'} }},
     }]);
     expect(result.authors).toEqual(['a', 'b']);

--- a/src/components/organisms/snippetCard/index.jsx
+++ b/src/components/organisms/snippetCard/index.jsx
@@ -1,70 +1,9 @@
-import React from 'react';
-import PropTypes from 'typedefs/proptypes';
-import { connect } from 'react-redux';
-
 import StandardSnippetCard from './standardSnippetCard';
 import CssSnippetCard from './cssSnippetCard';
 import BlogSnippetCard from './blogSnippetCard';
 
-export {
+export default {
   StandardSnippetCard,
   CssSnippetCard,
   BlogSnippetCard,
 };
-
-const propTypes = {
-  cardTemplate: PropTypes.string,
-  hasGithubLinksEnabled: PropTypes.bool,
-  dispatch: PropTypes.func,
-  rest: PropTypes.any,
-};
-
-/**
- * Renders a snippet card. (Redux-connected)
- * Used in snippet pages.
- * Dependent on its internal components to implement the desired functionality.
- */
-const SnippetCard = ({
-  cardTemplate,
-  hasGithubLinksEnabled,
-  // Keep dispatch here, as to not pass it down the component tree and get errors.
-  // eslint-disable-next-line no-unused-vars
-  dispatch,
-  ...rest
-}) => {
-  switch (cardTemplate) {
-  case 'blog':
-    return (
-      <BlogSnippetCard
-        hasGithubLinksEnabled={ !!hasGithubLinksEnabled }
-        { ...rest }
-      />
-    );
-  case 'css':
-    return (
-      <CssSnippetCard
-        hasGithubLinksEnabled={ !!hasGithubLinksEnabled }
-        { ...rest }
-      />
-    );
-  case 'standard':
-  default:
-    return (
-      <StandardSnippetCard
-        hasGithubLinksEnabled={ !!hasGithubLinksEnabled }
-        { ...rest }
-      />
-    );
-  }
-};
-
-SnippetCard.displayName = 'SnippetCardWrapper';
-
-SnippetCard.propTypes = propTypes;
-
-export default connect(
-  state => ({
-    hasGithubLinksEnabled: state.shell.hasGithubLinksEnabled,
-  }),
-  null
-)(SnippetCard);

--- a/src/components/organisms/snippetCard/index.test.jsx
+++ b/src/components/organisms/snippetCard/index.test.jsx
@@ -4,7 +4,7 @@ import createStore from 'state';
 import { mount, configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-import SnippetCard from './index';
+import cards from './index';
 import { fullSnippet, fullCssSnippet, fullBlogSnippet } from 'fixtures/snippets';
 
 configure({ adapter: new Adapter() });
@@ -18,9 +18,10 @@ describe('<SnippetCardWrapper />', () => {
   describe('standard snippet card template', () => {
 
     beforeAll(() => {
+      const SnippetCard = cards['StandardSnippetCard'];
       wrapper = mount(
         <Provider store={ store }>
-          <SnippetCard cardTemplate='standard' snippet={ fullSnippet } />
+          <SnippetCard snippet={ fullSnippet } />
         </Provider>
       );
     });
@@ -33,9 +34,10 @@ describe('<SnippetCardWrapper />', () => {
   describe('css snippet card template', () => {
 
     beforeAll(() => {
+      const SnippetCard = cards['CssSnippetCard'];
       wrapper = mount(
         <Provider store={ store }>
-          <SnippetCard cardTemplate='css' snippet={ fullCssSnippet }/>
+          <SnippetCard snippet={ fullCssSnippet }/>
         </Provider>
       );
     });
@@ -48,9 +50,10 @@ describe('<SnippetCardWrapper />', () => {
   describe('blog snippet card template', () => {
 
     beforeAll(() => {
+      const SnippetCard = cards['BlogSnippetCard'];
       wrapper = mount(
         <Provider store={ store }>
-          <SnippetCard cardTemplate='blog' snippet={ fullBlogSnippet }/>
+          <SnippetCard snippet={ fullBlogSnippet }/>
         </Provider>
       );
     });

--- a/src/components/templates/snippetPage/index.jsx
+++ b/src/components/templates/snippetPage/index.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import Meta from 'components/organisms/meta';
 import Breadcrumbs from 'components/molecules/breadcrumbs';
 import Shell from 'components/organisms/shell';
-import SnippetCard from 'components/organisms/snippetCard';
+import cardComponents from 'components/organisms/snippetCard';
 import RecommendationList from 'components/organisms/recommendationList';
 import CTA from 'components/organisms/cta';
 
@@ -23,6 +23,7 @@ const propTypes = {
       })
     ),
   }),
+  hasGithubLinksEnabled: PropTypes.bool,
   lastPageTitle: PropTypes.string.isRequired,
   lastPageUrl: PropTypes.string.isRequired,
 };
@@ -41,50 +42,55 @@ const SnippetPage = ({
     breadcrumbs,
     pageDescription,
   },
+  hasGithubLinksEnabled,
   lastPageTitle,
   lastPageUrl,
-}) => (
-  <>
-    <Meta
-      title={ snippet.title }
-      description={ pageDescription }
-      logoSrc={ cardTemplate === 'blog' ? snippet.cover.src : splashLogoSrc }
-      structuredData={ {
-        title: snippet.title,
-        description: snippet.description,
-        slug: snippet.slug,
-        orgLogoSrc: logoSrc,
-        firstSeen: snippet.firstSeen,
-        lastUpdated: snippet.lastUpdated,
-      } }
-      breadcrumbsData={ breadcrumbs }
-      canonical={ snippet.slug }
-    />
-    <Shell logoSrc={ logoSrc } >
-      <Breadcrumbs
-        lastPage={ {
-          link: {
-            url: lastPageUrl,
-            internal: true,
-          },
-          name: lastPageTitle,
+}) => {
+  const SnippetCard = cardComponents[cardTemplate];
+  return (
+    <>
+      <Meta
+        title={ snippet.title }
+        description={ pageDescription }
+        logoSrc={ cardTemplate === 'BlogSnippetCard' ? snippet.cover.src : splashLogoSrc }
+        structuredData={ {
+          title: snippet.title,
+          description: snippet.description,
+          slug: snippet.slug,
+          orgLogoSrc: logoSrc,
+          firstSeen: snippet.firstSeen,
+          lastUpdated: snippet.lastUpdated,
         } }
-        breadcrumbs={ breadcrumbs }
+        breadcrumbsData={ breadcrumbs }
+        canonical={ snippet.slug }
       />
-      <SnippetCard
-        cardTemplate={ cardTemplate }
-        snippet={ snippet }
-      />
-      <CTA/>
-      <RecommendationList snippetList={ recommendedSnippets } />
-    </Shell>
-  </>
-);
+      <Shell logoSrc={ logoSrc } >
+        <Breadcrumbs
+          lastPage={ {
+            link: {
+              url: lastPageUrl,
+              internal: true,
+            },
+            name: lastPageTitle,
+          } }
+          breadcrumbs={ breadcrumbs }
+        />
+        <SnippetCard
+          snippet={ snippet }
+          hasGithubLinksEnabled={ !!hasGithubLinksEnabled }
+        />
+        <CTA/>
+        <RecommendationList snippetList={ recommendedSnippets } />
+      </Shell>
+    </>
+  );
+};
 
 SnippetPage.propTypes = propTypes;
 
 export default connect(
   state => ({
+    hasGithubLinksEnabled: state.shell.hasGithubLinksEnabled,
     lastPageTitle: state.navigation.lastPageTitle,
     lastPageUrl: state.navigation.lastPageUrl,
   }),

--- a/src/components/templates/snippetPage/index.test.jsx
+++ b/src/components/templates/snippetPage/index.test.jsx
@@ -16,7 +16,7 @@ const { store } = createStore();
 describe('<SnippetPage />', () => {
   const logoSrc = '/assets/logo.png';
   const splashLogoSrc = '/assets/splash.png';
-  const cardTemplate = 'standard';
+  const cardTemplate = 'StandardSnippetCard';
   let wrapper, shell, meta, crumbs, snippetCard;
 
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe('<SnippetPage />', () => {
     shell = wrapper.find('Shell');
     meta = wrapper.find('Meta');
     crumbs = wrapper.find('Breadcrumbs');
-    snippetCard = wrapper.find('SnippetCardWrapper');
+    snippetCard = wrapper.find('SnippetCard');
   });
 
   describe('should render', () => {
@@ -70,10 +70,6 @@ describe('<SnippetPage />', () => {
     expect(crumbs.prop('breadcrumbs')).toBe(breadcrumbs);
   });
 
-  it('should pass the card template data to the SnippetCard component', () => {
-    expect(snippetCard.prop('cardTemplate')).toEqual(cardTemplate);
-  });
-
   it('should pass the snippet data to the SnippetCard component', () => {
     expect(snippetCard.prop('snippet')).toEqual(fullSnippet);
   });
@@ -86,7 +82,7 @@ describe('<SnippetPage />', () => {
             snippet: fullBlogSnippet,
             splashLogoSrc,
             logoSrc,
-            cardTemplate: 'blog',
+            cardTemplate: 'BlogSnippetCard',
             pageDescription: '',
             breadcrumbs,
           } }/>


### PR DESCRIPTION
- Remove the generic `SnippetCardWrapper` HOC.
- Update `cardTemplate` values to match the `SnippetCard` components 1-1.
- Update backend code to match the `cardTemplate` value updates.