### PR TITLE
Fix XMLs injected with data-react-helmet

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,4 +1,32 @@
 /*
   Gatsby SSR API
 */
-export { default as wrapRootElement } from 'state/ReduxWrapper';
+import ReduxWrapper from 'state/ReduxWrapper';
+import React from 'react';
+
+/**
+ * Wraps the whole application in a redux Provider.
+ */
+export const wrapRootElement = ReduxWrapper;
+
+/**
+ * Called after rendering a page. Injects sitemap and opensearch XMLs.
+ * TODO: Improve and extract outside of this file, if/when possible.
+ */
+export const onRenderBody = ({ setHeadComponents }) => {
+  setHeadComponents([
+    <link
+      key="link-sitemap"
+      rel="sitemap"
+      href="/sitemap.xml"
+      type="application/xml"
+    />,
+    <link
+      key="link-opensearch"
+      rel="search"
+      href="/opensearch.xml"
+      type="application/opensearchdescription+xml"
+      title="Snippet search"
+    />,
+  ]);
+};

--- a/src/components/organisms/meta/index.jsx
+++ b/src/components/organisms/meta/index.jsx
@@ -200,17 +200,6 @@ const Meta = ({
         key="preconnect-google-analytics"
         href="https://www.google-analytics.com"
       />
-      <link
-        rel="sitemap"
-        href="/sitemap.xml"
-        type="application/xml"
-      />
-      <link
-        rel="search"
-        href="/opensearch.xml"
-        type="application/opensearchdescription+xml"
-        title="Snippet search"
-      />
       {
         canonical ?
           <link


### PR DESCRIPTION
Fixes #162

Replace links in the `<Meta>` component with ones injected during SSR to avoid issues with the `data-react-helmet` property breaking Google-indexable XMLs.