### PR TITLE
Font smoothing on MacOS #214

### DIFF
--- a/src/components/atoms/card/_index.scss
+++ b/src/components/atoms/card/_index.scss
@@ -33,6 +33,7 @@
 
   .card-title {
     font-size: 1.5rem;
+    -webkit-font-smoothing: antialiased;
     font-weight: 500;
     line-height: 2rem;
     margin: 0 0.5rem;


### PR DESCRIPTION
Changes:

- -webkit-font-smoothing: antialiased; is inserted in .card-title class.

What it do:

- Above statement will make card title's edges more sharp in MacOS. 
- That will resolve the font smoothing on MacOS issue.

![Capture](https://user-images.githubusercontent.com/34315243/102715070-c5a24200-42f8-11eb-84be-84450a6bd8fd.PNG)
