### PR TITLE
Replace React with Preact only in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  webpack: (config, { dev, isServer }) => {
+    // Replace React with Preact only in client production build
+    if (!dev && !isServer) {
+      Object.assign(config.resolve.alias, {
+        react: 'preact/compat',
+        'react-dom/test-utils': 'preact/test-utils',
+        'react-dom': 'preact/compat',
+      });
+    }
+
+    return config;
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11172,6 +11172,12 @@
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
+    "preact": {
+      "version": "10.5.14",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.5.14.tgz",
+      "integrity": "sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "next": "^10.1.3",
     "node-fetch": "^2.6.1",
     "node-sass": "^4.14.1",
+    "preact": "^10.5.14",
     "prettier": "^2.2.1",
     "prismjs": "^1.23.0",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Improve page performance quite substantially by replacing React with Preact in production builds.

#### Before

```
Page                                                           Size     First Load JS
┌ ● /                                                          1.42 kB        69.6 kB
├   /_app                                                      0 B            60.3 kB
├ ● /[lang]/[...listing]                                       2.02 kB        70.2 kB
├   ├ /articles/p/1
├   ├ /articles/p/2
├   ├ /articles/p/3
├   └ [+257 more paths]
├ ● /[lang]/s/[snippet]                                        4.85 kB          73 kB
├   ├ /articles/s/10-vs-code-extensions-for-js-developers
├   ├ /articles/s/25-css-gradients
├   ├ /articles/s/4-javascript-array-methods
├   └ [+1050 more paths]
├ ○ /404                                                       946 B          69.1 kB
├ ● /about                                                     1 kB           69.2 kB
├ ● /collections                                               877 B          69.1 kB
├ ● /cookies                                                   1 kB           69.2 kB
└ ● /search                                                    2.1 kB         70.3 kB
+ First Load JS shared by all                                  60.3 kB
  ├ chunks/4076e8d4e3d94f598b10826c5bc2972376a69f8a.938db2.js  3.39 kB
  ├ chunks/commons.0423aa.js                                   8.71 kB
  ├ chunks/framework.608e6c.js                                 40.4 kB
  ├ chunks/main.c41b35.js                                      6.21 kB
  ├ chunks/pages/_app.728988.js                                889 B
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/ae9cf896b70752eb842e.css                               7.83 kB
```

#### After

```
Page                                                           Size     First Load JS
┌ ● /                                                          1.42 kB        37.6 kB
├   /_app                                                      0 B            27.8 kB
├ ● /[lang]/[...listing]                                       2.02 kB        38.2 kB
├   ├ /articles/p/1
├   ├ /articles/p/2
├   ├ /articles/p/3
├   └ [+257 more paths]
├ ● /[lang]/s/[snippet]                                        4.71 kB        40.9 kB
├   ├ /articles/s/10-vs-code-extensions-for-js-developers
├   ├ /articles/s/25-css-gradients
├   ├ /articles/s/4-javascript-array-methods
├   └ [+1050 more paths]
├ ○ /404                                                       946 B          37.1 kB
├ ● /about                                                     1 kB           37.2 kB
├ ● /collections                                               874 B            37 kB
├ ● /cookies                                                   1 kB           37.2 kB
└ ● /search                                                    2.1 kB         38.3 kB
+ First Load JS shared by all                                  27.8 kB
  ├ chunks/4076e8d4e3d94f598b10826c5bc2972376a69f8a.71f416.js  3.65 kB
  ├ chunks/commons.c68b18.js                                   16.3 kB
  ├ chunks/main.94039e.js                                      6.2 kB
  ├ chunks/pages/_app.e3a75e.js                                887 B
  ├ chunks/webpack.50bee0.js                                   751 B
  └ css/ae9cf896b70752eb842e.css                               7.83 kB
```