### PR TITLE
Add from param to internal links

### DIFF
--- a/src/components/atoms/breadcrumbs/index.jsx
+++ b/src/components/atoms/breadcrumbs/index.jsx
@@ -25,7 +25,7 @@ const Breadcrumbs = ({ breadcrumbs }) => (
               isCurrentPage ? 'txt-050 f-ellipsis' : 'txt-150'
             }`}
           >
-            <Link href={url}>
+            <Link href={`${url}?from=breadcrumbs`}>
               <a
                 className='inherit'
                 aria-current={isCurrentPage ? 'page' : null}

--- a/src/components/atoms/collectionChip/index.jsx
+++ b/src/components/atoms/collectionChip/index.jsx
@@ -12,7 +12,7 @@ const propTypes = {
  */
 const CollectionChip = ({ chip }) => (
   <li className='collection-chip srfc-01dp txt-200 br-xl'>
-    <Link href={chip.url}>
+    <Link href={`${chip.url}?from=chips`}>
       <a
         className={`inherit relative py-2 px-1 f-center flex j-center a-center f-alt box-border icon icon-${chip.icon} before:fs-lg`}
       >

--- a/src/components/atoms/collectionChip/index.test.js
+++ b/src/components/atoms/collectionChip/index.test.js
@@ -22,7 +22,7 @@ describe('<CollectionChip />', () => {
   });
 
   it('should have the correct link', () => {
-    expect(wrapper.querySelector('a').href).toBe(collectionChip.url);
+    expect(wrapper.querySelector('a').href).toContain(collectionChip.url);
   });
 
   it('should have the correct text', () => {

--- a/src/components/atoms/listingAnchors/index.jsx
+++ b/src/components/atoms/listingAnchors/index.jsx
@@ -38,7 +38,7 @@ const ListingAnchors = ({ items = [] }) => {
     >
       {items.map(item => (
         <li className='flex-none my-1 mx-0' key={item.url}>
-          <Link href={item.url}>
+          <Link href={`${item.url}?from=anchors`}>
             <a
               className={`btn action-btn ${item.selected ? 'selected' : ''}`}
               ref={item.selected ? selectedRef : undefined}

--- a/src/components/molecules/paginator/index.jsx
+++ b/src/components/molecules/paginator/index.jsx
@@ -28,7 +28,7 @@ const Paginator = ({ paginator: { pageNumber, totalPages, baseUrl } }) => {
   return (
     <div className='paginator mt-7 mx-5 mb-6 a-center flex j-center'>
       {pageNumber > 1 && (
-        <Link href={`${baseUrl}/p/${pageNumber - 1}`}>
+        <Link href={`${baseUrl}/p/${pageNumber - 1}?from=paginator`}>
           <a
             className='btn action-btn previous-page j-center fs-no md:fs-sm icon icon-chevron-left box-border before:fs-md'
             rel='prev'
@@ -43,13 +43,16 @@ const Paginator = ({ paginator: { pageNumber, totalPages, baseUrl } }) => {
             {buttonNumber}
           </span>
         ) : (
-          <Link key={buttonNumber} href={`${baseUrl}/p/${buttonNumber}`}>
+          <Link
+            key={buttonNumber}
+            href={`${baseUrl}/p/${buttonNumber}?from=paginator`}
+          >
             <a className='btn action-btn fs-md box-border'>{buttonNumber}</a>
           </Link>
         )
       )}
       {pageNumber < totalPages && (
-        <Link href={`${baseUrl}/p/${pageNumber + 1}`}>
+        <Link href={`${baseUrl}/p/${pageNumber + 1}?from=paginator`}>
           <a
             className='btn action-btn next-page j-center fs-no md:fs-sm icon icon-chevron-right box-border before:fs-md'
             rel='next'

--- a/src/components/molecules/previewCard/index.jsx
+++ b/src/components/molecules/previewCard/index.jsx
@@ -5,6 +5,7 @@ import literals from 'lang/en/client/common';
 
 const propTypes = {
   contentItem: PropTypes.oneOfType([PropTypes.snippet, PropTypes.chip]),
+  fromParam: PropTypes.string,
 };
 
 /**
@@ -12,8 +13,9 @@ const propTypes = {
  * Used in listing pages and search results.
  * Dependent on the `Card` component.
  * @param {object} contentItem - Snippet or collection object for the card.
+ * @param {string} fromParam - A string to pass to the `from` param.
  */
-const PreviewCard = ({ contentItem }) => {
+const PreviewCard = ({ contentItem, fromParam }) => {
   const isSnippet = Boolean(contentItem.expertise);
   const tags = !isSnippet
     ? [literals.snippetCollection]
@@ -35,7 +37,13 @@ const PreviewCard = ({ contentItem }) => {
       />
       <div className='card-data'>
         <CardTitle isSecondary>
-          <Link href={contentItem.url}>
+          <Link
+            href={
+              fromParam
+                ? `${contentItem.url}?from=${fromParam}`
+                : contentItem.url
+            }
+          >
             <a className='inherit'>{contentItem.title}</a>
           </Link>
         </CardTitle>

--- a/src/components/molecules/search/index.jsx
+++ b/src/components/molecules/search/index.jsx
@@ -134,8 +134,13 @@ const Search = ({ isMainSearch = false }) => {
             document.activeElement.blur();
             const { basePath } = router;
             if (!isMainSearch) {
-              if (selectedResult !== -1 && selectedResult !== 4) {
-                router.push(`${basePath}${searchResults[selectedResult].url}`);
+              if (
+                selectedResult !== -1 &&
+                selectedResult < searchResults.length - 1
+              ) {
+                router.push(
+                  `${basePath}${searchResults[selectedResult].url}?from=autocomplete`
+                );
               } else {
                 const encodedValue = encodeURIComponent(value);
                 router.push(
@@ -168,10 +173,14 @@ const Search = ({ isMainSearch = false }) => {
               )}`,
               search: true,
             },
-          ].map((item, i) => (
+          ].map((item, i, arr) => (
             <li key={`autocomplete-result-${item.url}`}>
               <a
-                href={item.url}
+                href={
+                  i === arr.length - 1
+                    ? item.url
+                    : `${item.url}?from=autocomplete`
+                }
                 title={item.title}
                 className={`flex py-2 px-3 ${
                   selectedResult === i ? 'selected' : ''

--- a/src/components/organisms/previewCardList/index.jsx
+++ b/src/components/organisms/previewCardList/index.jsx
@@ -5,18 +5,20 @@ const propTypes = {
   contentItems: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.snippet, PropTypes.chip])
   ),
+  fromParam: PropTypes.string,
 };
 
 /**
  * Renders a list of preview cards.
  * Dependent on the `PreviewCard` component.
  */
-const PreviewCardList = ({ contentItems }) => (
+const PreviewCardList = ({ contentItems, fromParam }) => (
   <ul className='list-section'>
     {contentItems.map(contentItem => (
       <PreviewCard
         key={`preview_${contentItem.url}`}
         contentItem={contentItem}
+        fromParam={fromParam}
       />
     ))}
   </ul>

--- a/src/components/organisms/recommendationList/index.jsx
+++ b/src/components/organisms/recommendationList/index.jsx
@@ -26,7 +26,10 @@ const RecommendationList = ({ snippetList, collectionChip = null }) => {
           <span dangerouslySetInnerHTML={{ __html: literals.andCollections }} />
         ) : null}
       </PageTitle>
-      <PreviewCardList contentItems={recommendations} />
+      <PreviewCardList
+        contentItems={recommendations}
+        fromParam='recommendations'
+      />
     </>
   ) : null;
 };

--- a/src/components/organisms/shelf/index.jsx
+++ b/src/components/organisms/shelf/index.jsx
@@ -25,7 +25,7 @@ const Shelf = ({ shelf: { shelfType, shelfData, shelfName, shelfUrl } }) => {
   const classPrefix = `${shelfType}-shelf`;
   return shelfData.length ? (
     <>
-      <Link href={shelfUrl}>
+      <Link href={`${shelfUrl}?from=shelves`}>
         <a
           className='shelf-title relative mt-8 icon icon-chevron-right before:fs-sm'
           data-link-title={literals.viewAll}
@@ -40,6 +40,7 @@ const Shelf = ({ shelf: { shelfType, shelfData, shelfName, shelfUrl } }) => {
               <PreviewCard
                 key={`snippet_${snippet.url}`}
                 contentItem={snippet}
+                fromParam='shelves'
               />
             ))
           : shelfData.map(chip => (


### PR DESCRIPTION
Add a `from` param to all internal links as follows:

- `?from=breadcrumbs` for breadcrumb links
- `?from=chips` for links to collections via chips
- `?from=shelves` for links to snippets from the home page
- `?from=paginator` for paginator buttons
- `?from=anchors` for listing anchors
- `?from=autocomplete` for search autocomplete links (excluding the search page link)
- `?from=recommendations` for recommended snippets and collections